### PR TITLE
APPS 1927 Fix minor issues with CLIP Notebook

### DIFF
--- a/notebooks/notebooks/clip_tutorial.ipynb
+++ b/notebooks/notebooks/clip_tutorial.ipynb
@@ -88,9 +88,9 @@
    "source": [
     "## <a id='setup-environment'></a>3. Set Up Dataloop Environment\n",
     "\n",
-    "To begin, we need to connect to the Dataloop platform. If you're not already logged in, running the cell below will prompt you to do so. Then, we'll either create a new project or get an existing one to work with.\n",
+    "We need to set up our Dataloop environment and get our project. You'll need to replace project and dataset names with your own values.\n",
     "\n",
-    "> **_NOTE:_** This tutorial assumes you are working in a new project which does NOT have the CLIP model previously installed. If it's an existing project and you already have CLIP installed, you will need to get the appropriate app and base CLIP model entity for the rest of the code to work correctly.\n",
+    "> **_NOTE:_**  This tutorial assumes you are working in a new project which does NOT have the CLIP model previously installed. If it's an existing project and you already have CLIP installed, you will need to get the appropriate app and base CLIP model entity for the rest of the code to work correctly.\n",
     "\n",
     "[Back to Top](#clip-contrastive-language-image-pre-training-model-adapter-tutorial)"
    ]
@@ -136,23 +136,7 @@
    "source": [
     "### <a id='use-public-dataset'></a>4.1 Option A: Use Public Dataset (Mars Surface Images)\n",
     "\n",
-    "For this tutorial, we can use the \"Mars Surface Images with Captions\" dataset, which can be installed from the Dataloop Marketplace.\n",
-    "\n",
-    "> **IMPORTANT NOTE ON PROJECT CONSISTENCY:**\n",
-    "> The Dataloop operations in this notebook (installing DPKs, getting datasets, training models) must all occur within the **same Dataloop project**.\n",
-    "> - In the [Set Up Dataloop Environment](#setup-environment) section (Cell 5), you defined `PROJECT_NAME` and the `project` variable was set.\n",
-    "> - However, a subsequent code cell (Cell 9) contains `project = dl.projects.get(\"test clip FT8\")`, which will **overwrite** the `project` variable to point to a specific project named \"test clip FT8\".\n",
-    "> \n",
-    "> **Please choose ONE of the following to ensure correct execution:**\n",
-    "> 1. **If you want to use a specific, existing project named \"test clip FT8\" for everything:**\n",
-    ">    - Modify `PROJECT_NAME` in Cell 5 to be `\"test clip FT8\"`.\n",
-    ">    - Ensure the \"Mars Surface Images DPK\" (Cell 7) is installed into this \"test clip FT8\" project.\n",
-    ">    - Cell 9 will then redundantly get the same project, which is fine.\n",
-    "> 2. **If you want to use the project defined by `PROJECT_NAME` (e.g., a new project you just created or a different existing project):**\n",
-    ">    - **Comment out or delete Cell 9** (`project = dl.projects.get(\"test clip FT8\")`).\n",
-    ">    - The \"Mars Surface Images DPK\" (Cell 7) will then be installed into the project specified by `PROJECT_NAME`.\n",
-    "> \n",
-    "> **Failure to ensure project consistency will lead to errors, such as not finding datasets or DPKs in the expected project.** The `dl.projects.create` function in Cell 5 will try to create the project or get it if it exists. If you choose option 1, make sure \"test clip FT8\" project exists or can be created by you."
+    "For this tutorial we will install the Mars Surface Images Datasets from the Dataloop Marketplace. This dataset includes images with descriptions pre-loaded in the item metadata."
    ]
   },
   {


### PR DESCRIPTION
This pull request updates the `clip_tutorial.ipynb` notebook to simplify instructions and improve clarity for setting up the Dataloop environment and using datasets. The changes streamline the tutorial by removing redundant information and focusing on essential steps.

### Updates to tutorial instructions:

* **Simplified environment setup instructions**: Revised the description for setting up the Dataloop environment to remove login prompts and clarify the need for users to replace project and dataset names with their own values.

* **Streamlined dataset usage section**: Removed detailed instructions about project consistency and options for handling the `PROJECT_NAME` variable, replacing them with a simplified explanation for installing the Mars Surface Images dataset from the Dataloop Marketplace.…ed dataset usage for the Mars Surface Images tutorial.